### PR TITLE
🔗 Wire Hydrant Inventory UI to Live API (CRUD)

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+});
+
+export const listHydrants = async ({ q = '', nfpa_class = '', status = '', page = 1, limit = 100 } = {}) => {
+  const params = {};
+  if (q) params.q = q;
+  if (nfpa_class) params.nfpa_class = nfpa_class;
+  if (status) params.status = status;
+  params.page = page;
+  params.limit = limit;
+  const res = await api.get('/hydrants', { params });
+  return res.data;
+};
+
+export const createHydrant = async (payload) => {
+  const res = await api.post('/hydrants', payload);
+  return res.data;
+};
+
+export const updateHydrant = async (id, payload) => {
+  const res = await api.put(`/hydrants/${id}`, payload);
+  return res.data;
+};
+
+export const deleteHydrant = async (id) => {
+  const res = await api.delete(`/hydrants/${id}`);
+  return res.data;
+};
+
+export default api;


### PR DESCRIPTION
## 🔗 Frontend Wiring: Hydrants UI ⇄ Live API

This PR connects the Hydrant Inventory page to the backend Hydrants API.

### Changes
- Added `frontend/src/services/api.js` – Axios client with helpers: listHydrants, createHydrant, updateHydrant, deleteHydrant
- Updated `frontend/src/pages/Hydrants.js` – Replaced demo data with live API calls, added Add/Edit/Delete via dialog
- Dialog form for creating/updating hydrants with lat/lon entry
- Search bar triggers server-side filtering via `q` parameter

### How to Run
```bash
# Backend
cd backend && npm run dev

# Frontend
cd frontend
echo "VITE_API_URL=http://localhost:5000/api" > .env
npm run dev
```

### Test Flow
1. Open Hydrants page
2. Search to filter server-side
3. Click "Add Hydrant" to create a new record
4. Select a row and click "Edit" to update
5. Select a row and click "Delete" to remove
6. Map sync: clicking markers selects and focuses hydrant

### Next Steps
- Add form validation (React Hook Form + Zod)
- Add toaster notifications for success/error
- Add filters for status and NFPA class
- Add GET `/api/hydrants/:id` for detailed view
